### PR TITLE
feat: Full CRUD Category Manager with icon/color picker

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,6 +19,7 @@ function RootLayoutNav() {
         <Stack.Screen name="report" />
         <Stack.Screen name="history" />
         <Stack.Screen name="settings" />
+        <Stack.Screen name="categories" />
       </Stack>
     </>
   );

--- a/app/categories.tsx
+++ b/app/categories.tsx
@@ -1,0 +1,12 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTheme } from '@/theme/ThemeContext';
+import CategoryManagerScreen from '@/screens/CategoryManagerScreen';
+
+export default function CategoriesPage() {
+  const { colors } = useTheme();
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }} edges={['top']}>
+      <CategoryManagerScreen />
+    </SafeAreaView>
+  );
+}

--- a/src/components/CategoryBar.tsx
+++ b/src/components/CategoryBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { CATEGORY_EMOJIS, formatCurrency } from '@/services/constants';
+import { formatCurrency } from '@/services/constants';
 import { useTheme } from '@/theme/ThemeContext';
 
 interface Props {
@@ -8,18 +8,20 @@ interface Props {
   total: number;
   currency: string;
   percentage: number; // 0–1
-  customEmojiMap: Record<string, string>;
+  categoryEmoji: string;
+  categoryColor: string;
 }
 
-export default function CategoryBar({ category, total, currency, percentage, customEmojiMap }: Props) {
+export default function CategoryBar({
+  category, total, currency, percentage, categoryEmoji, categoryColor,
+}: Props) {
   const { colors } = useTheme();
-  const emoji = CATEGORY_EMOJIS[category] ?? customEmojiMap[category] ?? '📦';
 
   return (
-    <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+    <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}>
       <View style={styles.row}>
-        <View style={[styles.icon, { backgroundColor: colors.inputFill }]}>
-          <Text style={styles.emoji}>{emoji}</Text>
+        <View style={[styles.badge, { backgroundColor: categoryColor }]}>
+          <Text style={styles.emoji}>{categoryEmoji}</Text>
         </View>
         <Text style={[styles.name, { color: colors.textPrimary }]}>{category}</Text>
         <View style={styles.right}>
@@ -35,7 +37,7 @@ export default function CategoryBar({ category, total, currency, percentage, cus
         <View
           style={[
             styles.fill,
-            { width: `${Math.min(percentage * 100, 100)}%`, backgroundColor: colors.primary },
+            { width: `${Math.min(percentage * 100, 100)}%`, backgroundColor: categoryColor },
           ]}
         />
       </View>
@@ -44,14 +46,9 @@ export default function CategoryBar({ category, total, currency, percentage, cus
 }
 
 const styles = StyleSheet.create({
-  card: {
-    padding: 14, borderRadius: 14, borderWidth: 1, marginBottom: 10,
-  },
+  card: { padding: 14, borderRadius: 14, borderWidth: 1, marginBottom: 10 },
   row: { flexDirection: 'row', alignItems: 'center', marginBottom: 10 },
-  icon: {
-    width: 40, height: 40, borderRadius: 10,
-    alignItems: 'center', justifyContent: 'center', marginRight: 12,
-  },
+  badge: { width: 40, height: 40, borderRadius: 20, alignItems: 'center', justifyContent: 'center', marginRight: 12 },
   emoji: { fontSize: 20 },
   name: { flex: 1, fontSize: 15, fontWeight: '600' },
   right: { alignItems: 'flex-end' },

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/theme/ThemeContext';
+import { Category } from '@/types';
+
+interface Props {
+  category: Category;
+  expenseCount: number;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export default function CategoryCard({ category, expenseCount, onEdit, onDelete }: Props) {
+  const { colors } = useTheme();
+  const isBuiltIn = category.isDefault === 1;
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.card }]}>
+      {/* Colored emoji badge */}
+      <View style={[styles.badge, { backgroundColor: category.color }]}>
+        <Text style={styles.badgeEmoji}>{category.emoji}</Text>
+      </View>
+
+      {/* Name + meta */}
+      <View style={styles.info}>
+        <Text style={[styles.name, { color: colors.textPrimary }]} numberOfLines={1}>
+          {category.name}
+        </Text>
+        <Text style={[styles.meta, { color: colors.textSecondary }]}>
+          {expenseCount > 0
+            ? `${expenseCount} expense${expenseCount > 1 ? 's' : ''}`
+            : 'No expenses yet'}
+        </Text>
+      </View>
+
+      {/* Lock badge for built-in */}
+      {isBuiltIn && (
+        <View style={[styles.lockBadge, { backgroundColor: colors.inputFill }]}>
+          <Ionicons name="lock-closed" size={11} color={colors.textSecondary} />
+          <Text style={[styles.lockText, { color: colors.textSecondary }]}>Built-in</Text>
+        </View>
+      )}
+
+      {/* Actions */}
+      <TouchableOpacity
+        onPress={onEdit}
+        style={[styles.actionBtn, { backgroundColor: colors.inputFill }]}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Ionicons name="pencil-outline" size={16} color={colors.primary} />
+      </TouchableOpacity>
+
+      {!isBuiltIn && (
+        <TouchableOpacity
+          onPress={onDelete}
+          style={[styles.actionBtn, { backgroundColor: colors.dangerBg, marginLeft: 6 }]}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons name="trash-outline" size={16} color={colors.danger} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 14,
+    padding: 14,
+    marginBottom: 10,
+  },
+  badge: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  badgeEmoji: { fontSize: 22 },
+  info: { flex: 1, marginRight: 8 },
+  name: { fontSize: 15, fontWeight: '700', marginBottom: 2 },
+  meta: { fontSize: 12 },
+  lockBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    marginRight: 8,
+    gap: 3,
+  },
+  lockText: { fontSize: 10, fontWeight: '600' },
+  actionBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/components/ExpenseTile.tsx
+++ b/src/components/ExpenseTile.tsx
@@ -2,20 +2,22 @@ import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Expense } from '@/types';
-import { CATEGORY_EMOJIS, formatCurrency, formatDate } from '@/services/constants';
+import { formatCurrency, formatDate } from '@/services/constants';
 import { useTheme } from '@/theme/ThemeContext';
 
 interface Props {
   expense: Expense;
   currency: string;
-  customEmojiMap: Record<string, string>;
+  categoryEmoji: string;
+  categoryColor: string;
   onEdit: () => void;
   onDelete: () => void;
 }
 
-export default function ExpenseTile({ expense, currency, customEmojiMap, onEdit, onDelete }: Props) {
+export default function ExpenseTile({
+  expense, currency, categoryEmoji, categoryColor, onEdit, onDelete,
+}: Props) {
   const { colors } = useTheme();
-  const emoji = CATEGORY_EMOJIS[expense.category] ?? customEmojiMap[expense.category] ?? '📦';
 
   const confirmDelete = () =>
     Alert.alert('Delete Expense', 'Are you sure you want to delete this expense?', [
@@ -24,10 +26,12 @@ export default function ExpenseTile({ expense, currency, customEmojiMap, onEdit,
     ]);
 
   return (
-    <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-      <View style={[styles.icon, { backgroundColor: colors.inputFill }]}>
-        <Text style={styles.emoji}>{emoji}</Text>
+    <View style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}>
+      {/* Colored category badge */}
+      <View style={[styles.badge, { backgroundColor: categoryColor }]}>
+        <Text style={styles.emoji}>{categoryEmoji}</Text>
       </View>
+
       <View style={styles.info}>
         <Text style={[styles.category, { color: colors.textPrimary }]}>{expense.category}</Text>
         {expense.note ? (
@@ -37,14 +41,16 @@ export default function ExpenseTile({ expense, currency, customEmojiMap, onEdit,
         ) : null}
         <Text style={[styles.date, { color: colors.textSecondary }]}>{formatDate(expense.createdAt)}</Text>
       </View>
+
       <Text style={[styles.price, { color: colors.danger }]}>
         -{formatCurrency(expense.price, currency)}
       </Text>
+
       <View style={styles.actions}>
-        <TouchableOpacity onPress={onEdit} style={styles.action}>
+        <TouchableOpacity onPress={onEdit} style={styles.action} hitSlop={{ top:8,bottom:8,left:8,right:8 }}>
           <Ionicons name="pencil-outline" size={18} color={colors.textSecondary} />
         </TouchableOpacity>
-        <TouchableOpacity onPress={confirmDelete} style={styles.action}>
+        <TouchableOpacity onPress={confirmDelete} style={styles.action} hitSlop={{ top:8,bottom:8,left:8,right:8 }}>
           <Ionicons name="trash-outline" size={18} color={colors.danger} />
         </TouchableOpacity>
       </View>
@@ -54,19 +60,12 @@ export default function ExpenseTile({ expense, currency, customEmojiMap, onEdit,
 
 const styles = StyleSheet.create({
   card: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 14,
-    borderRadius: 14,
-    borderWidth: 1,
-    marginBottom: 10,
+    flexDirection: 'row', alignItems: 'center',
+    padding: 14, borderRadius: 14, borderWidth: 1, marginBottom: 10,
   },
-  icon: {
-    width: 44, height: 44,
-    borderRadius: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginRight: 12,
+  badge: {
+    width: 44, height: 44, borderRadius: 22,
+    alignItems: 'center', justifyContent: 'center', marginRight: 12,
   },
   emoji: { fontSize: 22 },
   info: { flex: 1 },

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -6,9 +6,11 @@ import {
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/theme/ThemeContext';
-import { addExpense, updateExpense, getSettings, getExpensesByMonth } from '@/services/database';
-import { DEFAULT_CATEGORIES, CATEGORY_EMOJIS, currentMonthKey } from '@/services/constants';
-import { Expense, Settings } from '@/types';
+import {
+  addExpense, updateExpense, getCategories, getExpensesByMonth,
+} from '@/services/database';
+import { currentMonthKey } from '@/services/constants';
+import { Category, Expense } from '@/types';
 import AppInput from '@/components/AppInput';
 import AppButton from '@/components/AppButton';
 
@@ -19,36 +21,34 @@ export default function AddExpenseScreen() {
 
   const [editExpense, setEditExpense] = useState<Expense | null>(null);
   const [price, setPrice] = useState('');
-  const [category, setCategory] = useState(DEFAULT_CATEGORIES[0]);
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
   const [note, setNote] = useState('');
   const [priceError, setPriceError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [settings, setSettings] = useState<Settings | null>(null);
+  const [categories, setCategories] = useState<Category[]>([]);
 
   useEffect(() => {
     const init = async () => {
-      const sets = await getSettings();
-      setSettings(sets);
+      const cats = await getCategories();
+      setCategories(cats);
 
       if (expenseId) {
-        const monthKey = currentMonthKey();
-        const expenses = await getExpensesByMonth(monthKey);
-        const found = expenses.find(e => String(e.id) === expenseId);
+        const expenses = await getExpensesByMonth(currentMonthKey());
+        const found = expenses.find((e) => String(e.id) === expenseId);
         if (found) {
           setEditExpense(found);
           setPrice(String(found.price));
-          setCategory(found.category);
           setNote(found.note ?? '');
+          const cat = cats.find((c) => c.name === found.category);
+          setSelectedCategory(cat ?? cats[0] ?? null);
+          return;
         }
       }
+
+      setSelectedCategory(cats[0] ?? null);
     };
     init();
   }, [expenseId]);
-
-  const allCategories = [...DEFAULT_CATEGORIES, ...(settings?.customCategories ?? [])];
-
-  const getEmoji = (cat: string) =>
-    CATEGORY_EMOJIS[cat] ?? settings?.customCategoryEmojis?.[cat] ?? '📦';
 
   const validate = () => {
     const v = parseFloat(price.replace(',', '.'));
@@ -63,10 +63,11 @@ export default function AddExpenseScreen() {
     setLoading(true);
     try {
       const v = parseFloat(price.replace(',', '.'));
+      const catName = selectedCategory?.name ?? 'Other';
       if (editExpense) {
-        await updateExpense(editExpense.id, v, category, note.trim() || null);
+        await updateExpense(editExpense.id, v, catName, note.trim() || null);
       } else {
-        await addExpense(v, category, note.trim() || null);
+        await addExpense(v, catName, note.trim() || null);
       }
       router.back();
     } catch {
@@ -98,25 +99,28 @@ export default function AddExpenseScreen() {
           error={priceError}
         />
 
-        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>Category</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>CATEGORY</Text>
         <View style={styles.categoryGrid}>
-          {allCategories.map((cat) => {
-            const selected = cat === category;
+          {categories.map((cat) => {
+            const selected = selectedCategory?.id === cat.id;
             return (
               <TouchableOpacity
-                key={cat}
+                key={cat.id}
                 style={[
                   styles.categoryPill,
                   {
-                    backgroundColor: selected ? colors.primary : colors.inputFill,
-                    borderColor: selected ? colors.primary : colors.border,
+                    backgroundColor: selected ? cat.color : colors.inputFill,
+                    borderColor: selected ? cat.color : colors.border,
                   },
                 ]}
-                onPress={() => setCategory(cat)}
+                onPress={() => setSelectedCategory(cat)}
               >
-                <Text style={styles.pillEmoji}>{getEmoji(cat)}</Text>
-                <Text style={[styles.pillLabel, { color: selected ? colors.background : colors.textPrimary }]}>
-                  {cat}
+                <Text style={styles.pillEmoji}>{cat.emoji}</Text>
+                <Text style={[
+                  styles.pillLabel,
+                  { color: selected ? '#fff' : colors.textPrimary },
+                ]}>
+                  {cat.name}
                 </Text>
               </TouchableOpacity>
             );
@@ -151,7 +155,7 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 18, fontWeight: '700' },
   content: { padding: 20 },
-  sectionLabel: { fontSize: 13, fontWeight: '600', marginBottom: 10 },
+  sectionLabel: { fontSize: 11, fontWeight: '700', letterSpacing: 1, marginBottom: 10 },
   categoryGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginBottom: 20 },
   categoryPill: {
     flexDirection: 'row', alignItems: 'center',

--- a/src/screens/CategoryManagerScreen.tsx
+++ b/src/screens/CategoryManagerScreen.tsx
@@ -1,0 +1,517 @@
+import React, { useCallback, useState } from 'react';
+import {
+  View, Text, ScrollView, TouchableOpacity, StyleSheet,
+  Modal, TextInput, Alert, KeyboardAvoidingView, Platform,
+} from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/theme/ThemeContext';
+import {
+  getCategories, addCategory, updateCategory, deleteCategory,
+  getCategoryUsageCounts,
+} from '@/services/database';
+import { EMOJI_GROUPS, CATEGORY_COLORS } from '@/services/constants';
+import { Category } from '@/types';
+import CategoryCard from '@/components/CategoryCard';
+
+// ── Modal state type ──────────────────────────────────────────
+
+interface FormState {
+  mode: 'add' | 'edit';
+  target: Category | null;
+  name: string;
+  emoji: string;
+  color: string;
+  emojiGroup: number;
+  saving: boolean;
+  nameError: string;
+}
+
+const INITIAL_FORM: FormState = {
+  mode: 'add',
+  target: null,
+  name: '',
+  emoji: '📦',
+  color: CATEGORY_COLORS[0],
+  emojiGroup: 0,
+  saving: false,
+  nameError: '',
+};
+
+// ── Main screen ───────────────────────────────────────────────
+
+export default function CategoryManagerScreen() {
+  const { colors } = useTheme();
+  const router = useRouter();
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [usageCounts, setUsageCounts] = useState<Record<string, number>>({});
+  const [modalVisible, setModalVisible] = useState(false);
+  const [form, setForm] = useState<FormState>(INITIAL_FORM);
+
+  // ── Load data ───────────────────────────────────────────────
+
+  const load = useCallback(() => {
+    Promise.all([getCategories(), getCategoryUsageCounts()]).then(([cats, counts]) => {
+      setCategories(cats);
+      setUsageCounts(counts);
+    });
+  }, []);
+
+  useFocusEffect(load);
+
+  // ── Form helpers ────────────────────────────────────────────
+
+  const openAdd = () => {
+    setForm(INITIAL_FORM);
+    setModalVisible(true);
+  };
+
+  const openEdit = (cat: Category) => {
+    setForm({
+      mode: 'edit',
+      target: cat,
+      name: cat.name,
+      emoji: cat.emoji,
+      color: cat.color,
+      emojiGroup: 0,
+      saving: false,
+      nameError: '',
+    });
+    setModalVisible(true);
+  };
+
+  const closeModal = () => {
+    if (!form.saving) setModalVisible(false);
+  };
+
+  const setField = <K extends keyof FormState>(key: K, value: FormState[K]) =>
+    setForm((f) => ({ ...f, [key]: value }));
+
+  // ── Save ────────────────────────────────────────────────────
+
+  const handleSave = async () => {
+    const name = form.name.trim();
+    if (!name) {
+      setField('nameError', 'Category name is required.');
+      return;
+    }
+    setField('saving', true);
+    try {
+      if (form.mode === 'add') {
+        await addCategory(name, form.emoji, form.color);
+      } else if (form.target) {
+        await updateCategory(form.target.id, name, form.emoji, form.color);
+      }
+      setModalVisible(false);
+      load();
+    } catch (err: unknown) {
+      setField('saving', false);
+      setField('nameError', err instanceof Error ? err.message : 'Something went wrong.');
+    }
+  };
+
+  // ── Delete ──────────────────────────────────────────────────
+
+  const handleDelete = (cat: Category) => {
+    Alert.alert(
+      'Delete Category',
+      `Are you sure you want to delete "${cat.name}"?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            const result = await deleteCategory(cat.id);
+            if (!result.ok) {
+              Alert.alert('Cannot Delete', result.reason ?? 'Unknown error.');
+            } else {
+              load();
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  // ── Sections ────────────────────────────────────────────────
+
+  const builtIn = categories.filter((c) => c.isDefault === 1);
+  const custom  = categories.filter((c) => c.isDefault === 0);
+
+  // ── Render ──────────────────────────────────────────────────
+
+  return (
+    <View style={[styles.screen, { backgroundColor: colors.background }]}>
+
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <TouchableOpacity onPress={() => router.back()} hitSlop={{ top:8,bottom:8,left:8,right:8 }}>
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <View>
+          <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>Categories</Text>
+          <Text style={[styles.headerSub, { color: colors.textSecondary }]}>
+            {categories.length} total · {custom.length} custom
+          </Text>
+        </View>
+        <TouchableOpacity
+          style={[styles.headerAddBtn, { backgroundColor: colors.primary }]}
+          onPress={openAdd}
+        >
+          <Ionicons name="add" size={20} color={colors.background} />
+        </TouchableOpacity>
+      </View>
+
+      {/* List */}
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+
+        {/* Built-in */}
+        <SectionHeader label="Built-in" count={builtIn.length} colors={colors} />
+        {builtIn.map((cat) => (
+          <CategoryCard
+            key={cat.id}
+            category={cat}
+            expenseCount={usageCounts[cat.name] ?? 0}
+            onEdit={() => openEdit(cat)}
+            onDelete={() => handleDelete(cat)}
+          />
+        ))}
+
+        {/* Custom */}
+        <SectionHeader label="Custom" count={custom.length} colors={colors} style={{ marginTop: 10 }} />
+        {custom.length === 0 ? (
+          <EmptyCustom colors={colors} onAdd={openAdd} />
+        ) : (
+          custom.map((cat) => (
+            <CategoryCard
+              key={cat.id}
+              category={cat}
+              expenseCount={usageCounts[cat.name] ?? 0}
+              onEdit={() => openEdit(cat)}
+              onDelete={() => handleDelete(cat)}
+            />
+          ))
+        )}
+
+        <View style={{ height: 80 }} />
+      </ScrollView>
+
+      {/* FAB */}
+      <TouchableOpacity
+        style={[styles.fab, { backgroundColor: colors.primary }]}
+        onPress={openAdd}
+      >
+        <Ionicons name="add" size={28} color={colors.background} />
+      </TouchableOpacity>
+
+      {/* Add / Edit modal */}
+      <Modal visible={modalVisible} transparent animationType="slide" onRequestClose={closeModal}>
+        <KeyboardAvoidingView
+          style={styles.modalOverlay}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        >
+          <TouchableOpacity style={StyleSheet.absoluteFill} onPress={closeModal} />
+          <View style={[styles.sheet, { backgroundColor: colors.card }]}>
+            <CategoryForm
+              form={form}
+              setField={setField}
+              onSave={handleSave}
+              onClose={closeModal}
+              colors={colors}
+            />
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────
+
+function SectionHeader({
+  label, count, colors, style,
+}: { label: string; count: number; colors: ReturnType<typeof useTheme>['colors']; style?: object }) {
+  return (
+    <View style={[styles.sectionRow, style]}>
+      <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+        {label.toUpperCase()}
+      </Text>
+      <View style={[styles.countBadge, { backgroundColor: colors.inputFill }]}>
+        <Text style={[styles.countText, { color: colors.textSecondary }]}>{count}</Text>
+      </View>
+    </View>
+  );
+}
+
+function EmptyCustom({
+  colors, onAdd,
+}: { colors: ReturnType<typeof useTheme>['colors']; onAdd: () => void }) {
+  return (
+    <View style={[styles.emptyCard, { backgroundColor: colors.card, borderColor: colors.border }]}>
+      <Text style={styles.emptyEmoji}>🏷️</Text>
+      <Text style={[styles.emptyTitle, { color: colors.textPrimary }]}>No custom categories</Text>
+      <Text style={[styles.emptyDesc, { color: colors.textSecondary }]}>
+        Create your own to personalize expense tracking
+      </Text>
+      <TouchableOpacity
+        style={[styles.emptyBtn, { backgroundColor: colors.primary }]}
+        onPress={onAdd}
+      >
+        <Ionicons name="add" size={16} color={colors.background} />
+        <Text style={[styles.emptyBtnText, { color: colors.background }]}>Add Category</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+// ── Form sheet ────────────────────────────────────────────────
+
+interface FormProps {
+  form: FormState;
+  setField: <K extends keyof FormState>(key: K, val: FormState[K]) => void;
+  onSave: () => void;
+  onClose: () => void;
+  colors: ReturnType<typeof useTheme>['colors'];
+}
+
+function CategoryForm({ form, setField, onSave, onClose, colors }: FormProps) {
+  const isBuiltIn = form.target?.isDefault === 1;
+  const currentGroup = EMOJI_GROUPS[form.emojiGroup];
+
+  return (
+    <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+
+      {/* Sheet handle */}
+      <View style={[styles.handle, { backgroundColor: colors.border }]} />
+
+      {/* Title row */}
+      <View style={styles.sheetHeader}>
+        <Text style={[styles.sheetTitle, { color: colors.textPrimary }]}>
+          {form.mode === 'add' ? 'New Category' : 'Edit Category'}
+        </Text>
+        <TouchableOpacity onPress={onClose}>
+          <Ionicons name="close" size={22} color={colors.textSecondary} />
+        </TouchableOpacity>
+      </View>
+
+      {/* Preview badge */}
+      <View style={styles.previewRow}>
+        <View style={[styles.previewBadge, { backgroundColor: form.color }]}>
+          <Text style={styles.previewEmoji}>{form.emoji}</Text>
+        </View>
+        <View style={styles.previewInfo}>
+          <Text style={[styles.previewName, { color: colors.textPrimary }]}>
+            {form.name || 'Category Name'}
+          </Text>
+          {isBuiltIn && (
+            <Text style={[styles.previewSub, { color: colors.textSecondary }]}>
+              Built-in · emoji & color only
+            </Text>
+          )}
+        </View>
+      </View>
+
+      {/* Name input */}
+      {!isBuiltIn && (
+        <View style={styles.field}>
+          <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Name</Text>
+          <TextInput
+            style={[styles.textInput, { color: colors.textPrimary, backgroundColor: colors.inputFill, borderColor: form.nameError ? colors.danger : colors.border }]}
+            placeholder="e.g. Gym, Pets, Travel…"
+            placeholderTextColor={colors.textSecondary}
+            value={form.name}
+            onChangeText={(v) => { setField('name', v); setField('nameError', ''); }}
+            autoCapitalize="words"
+            maxLength={24}
+          />
+          {!!form.nameError && (
+            <Text style={[styles.errorText, { color: colors.danger }]}>{form.nameError}</Text>
+          )}
+        </View>
+      )}
+
+      {/* Color picker */}
+      <View style={styles.field}>
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Accent Color</Text>
+        <View style={styles.colorRow}>
+          {CATEGORY_COLORS.map((c) => (
+            <TouchableOpacity
+              key={c}
+              onPress={() => setField('color', c)}
+              style={[
+                styles.colorSwatch,
+                { backgroundColor: c },
+                form.color === c && styles.colorSelected,
+              ]}
+            >
+              {form.color === c && (
+                <Ionicons name="checkmark" size={14} color="#fff" />
+              )}
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+
+      {/* Emoji picker */}
+      <View style={styles.field}>
+        <Text style={[styles.fieldLabel, { color: colors.textSecondary }]}>Icon</Text>
+
+        {/* Group tabs */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.groupTabScroll}
+          contentContainerStyle={styles.groupTabContent}
+        >
+          {EMOJI_GROUPS.map((g, i) => (
+            <TouchableOpacity
+              key={g.label}
+              onPress={() => setField('emojiGroup', i)}
+              style={[
+                styles.groupTab,
+                { backgroundColor: form.emojiGroup === i ? colors.primary : colors.inputFill },
+              ]}
+            >
+              <Text style={styles.groupTabEmoji}>{g.icon}</Text>
+              <Text style={[
+                styles.groupTabLabel,
+                { color: form.emojiGroup === i ? colors.background : colors.textSecondary },
+              ]}>
+                {g.label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+
+        {/* Emoji grid */}
+        <View style={styles.emojiGrid}>
+          {currentGroup.emojis.map((em) => (
+            <TouchableOpacity
+              key={em}
+              onPress={() => setField('emoji', em)}
+              style={[
+                styles.emojiCell,
+                form.emoji === em && { backgroundColor: colors.primary + '33', borderRadius: 10 },
+              ]}
+            >
+              <Text style={styles.emojiCellText}>{em}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+
+      {/* Save button */}
+      <TouchableOpacity
+        style={[styles.saveBtn, { backgroundColor: form.saving ? colors.border : colors.primary }]}
+        onPress={onSave}
+        disabled={form.saving}
+      >
+        <Text style={[styles.saveBtnText, { color: colors.background }]}>
+          {form.saving ? 'Saving…' : form.mode === 'add' ? 'Create Category' : 'Save Changes'}
+        </Text>
+      </TouchableOpacity>
+
+      <View style={{ height: 30 }} />
+    </ScrollView>
+  );
+}
+
+// ── Styles ────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+
+  // Header
+  header: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 20, paddingVertical: 14, borderBottomWidth: 1,
+  },
+  headerTitle: { fontSize: 18, fontWeight: '700' },
+  headerSub: { fontSize: 12, marginTop: 1 },
+  headerAddBtn: {
+    width: 34, height: 34, borderRadius: 17,
+    alignItems: 'center', justifyContent: 'center',
+  },
+
+  // List
+  content: { padding: 16 },
+  sectionRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 10 },
+  sectionLabel: { fontSize: 11, fontWeight: '700', letterSpacing: 1 },
+  countBadge: { marginLeft: 8, paddingHorizontal: 7, paddingVertical: 2, borderRadius: 8 },
+  countText: { fontSize: 11, fontWeight: '600' },
+
+  // Empty state
+  emptyCard: {
+    borderRadius: 16, padding: 28, alignItems: 'center',
+    borderWidth: 1.5, borderStyle: 'dashed',
+  },
+  emptyEmoji: { fontSize: 40, marginBottom: 10 },
+  emptyTitle: { fontSize: 16, fontWeight: '700', marginBottom: 6 },
+  emptyDesc: { fontSize: 13, textAlign: 'center', marginBottom: 20, lineHeight: 18 },
+  emptyBtn: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    paddingHorizontal: 20, paddingVertical: 12, borderRadius: 12,
+  },
+  emptyBtnText: { fontSize: 14, fontWeight: '700' },
+
+  // FAB
+  fab: {
+    position: 'absolute', bottom: 28, right: 24,
+    width: 56, height: 56, borderRadius: 28,
+    alignItems: 'center', justifyContent: 'center',
+    elevation: 4, shadowOpacity: 0.25, shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+  },
+
+  // Modal
+  modalOverlay: { flex: 1, justifyContent: 'flex-end', backgroundColor: '#00000055' },
+  sheet: { borderTopLeftRadius: 24, borderTopRightRadius: 24, paddingHorizontal: 20, paddingBottom: 20, maxHeight: '90%' },
+  handle: { width: 40, height: 4, borderRadius: 2, alignSelf: 'center', marginTop: 12, marginBottom: 8 },
+  sheetHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 20 },
+  sheetTitle: { fontSize: 18, fontWeight: '700' },
+
+  // Preview
+  previewRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
+  previewBadge: { width: 56, height: 56, borderRadius: 28, alignItems: 'center', justifyContent: 'center', marginRight: 14 },
+  previewEmoji: { fontSize: 28 },
+  previewInfo: { flex: 1 },
+  previewName: { fontSize: 17, fontWeight: '700' },
+  previewSub: { fontSize: 12, marginTop: 3 },
+
+  // Fields
+  field: { marginBottom: 20 },
+  fieldLabel: { fontSize: 12, fontWeight: '600', marginBottom: 8, letterSpacing: 0.5 },
+  textInput: {
+    borderWidth: 1.5, borderRadius: 12,
+    paddingHorizontal: 14, paddingVertical: 12,
+    fontSize: 15,
+  },
+  errorText: { fontSize: 12, marginTop: 4 },
+
+  // Colors
+  colorRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
+  colorSwatch: {
+    width: 36, height: 36, borderRadius: 18,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  colorSelected: { borderWidth: 3, borderColor: '#fff' },
+
+  // Emoji picker
+  groupTabScroll: { marginBottom: 12 },
+  groupTabContent: { gap: 8, paddingBottom: 4 },
+  groupTab: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: 12, paddingVertical: 7, borderRadius: 20,
+  },
+  groupTabEmoji: { fontSize: 14 },
+  groupTabLabel: { fontSize: 12, fontWeight: '600' },
+  emojiGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 4 },
+  emojiCell: { width: '13%', aspectRatio: 1, alignItems: 'center', justifyContent: 'center' },
+  emojiCellText: { fontSize: 24 },
+
+  // Save
+  saveBtn: { borderRadius: 14, paddingVertical: 16, alignItems: 'center', marginTop: 8 },
+  saveBtnText: { fontSize: 16, fontWeight: '700' },
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -6,9 +6,9 @@ import {
 import { useFocusEffect, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/theme/ThemeContext';
-import { getExpensesByMonth, getIncomesByMonth, deleteExpense, deleteIncome, getSettings } from '@/services/database';
+import { getExpensesByMonth, getIncomesByMonth, deleteExpense, deleteIncome, getSettings, getCategories } from '@/services/database';
 import { currentMonthKey, monthKeyToLabel, formatCurrency } from '@/services/constants';
-import { Expense, Income, Settings } from '@/types';
+import { Category, Expense, Income, Settings } from '@/types';
 import SummaryCard from '@/components/SummaryCard';
 import ExpenseTile from '@/components/ExpenseTile';
 import IncomeTile from '@/components/IncomeTile';
@@ -27,6 +27,7 @@ export default function HomeScreen() {
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [incomes, setIncomes] = useState<Income[]>([]);
   const [settings, setSettings] = useState<Settings | null>(null);
+  const [categoryMap, setCategoryMap] = useState<Record<string, Category>>({});
   const [loading, setLoading] = useState(true);
   const [fabOpen, setFabOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'expenses' | 'income'>('expenses');
@@ -37,10 +38,14 @@ export default function HomeScreen() {
       getExpensesByMonth(monthKey),
       getIncomesByMonth(monthKey),
       getSettings(),
-    ]).then(([exps, incs, sets]) => {
+      getCategories(),
+    ]).then(([exps, incs, sets, cats]) => {
       setExpenses(exps);
       setIncomes(incs);
       setSettings(sets);
+      const map: Record<string, Category> = {};
+      cats.forEach((c) => (map[c.name] = c));
+      setCategoryMap(map);
       setLoading(false);
     });
   }, [monthKey]);
@@ -168,7 +173,8 @@ export default function HomeScreen() {
                 key={exp.id}
                 expense={exp}
                 currency={settings?.currency ?? 'EGP'}
-                customEmojiMap={settings?.customCategoryEmojis ?? {}}
+                categoryEmoji={categoryMap[exp.category]?.emoji ?? '📦'}
+                categoryColor={categoryMap[exp.category]?.color ?? '#408A71'}
                 onEdit={() => router.push({ pathname: '/add-expense', params: { expenseId: String(exp.id) } })}
                 onDelete={() => handleDeleteExpense(exp.id)}
               />

--- a/src/screens/ReportScreen.tsx
+++ b/src/screens/ReportScreen.tsx
@@ -5,9 +5,11 @@ import {
 import { useRouter, useLocalSearchParams, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/theme/ThemeContext';
-import { getExpensesByMonth, getIncomesByMonth, getSettings, deleteExpense } from '@/services/database';
+import {
+  getExpensesByMonth, getIncomesByMonth, getSettings, deleteExpense, getCategories,
+} from '@/services/database';
 import { monthKeyToLabel, formatCurrency } from '@/services/constants';
-import { Expense, Income, Settings } from '@/types';
+import { Category, Expense, Income, Settings } from '@/types';
 import ExpenseTile from '@/components/ExpenseTile';
 import IncomeTile from '@/components/IncomeTile';
 import CategoryBar from '@/components/CategoryBar';
@@ -20,6 +22,7 @@ export default function ReportScreen() {
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [incomes, setIncomes] = useState<Income[]>([]);
   const [settings, setSettings] = useState<Settings | null>(null);
+  const [categoryMap, setCategoryMap] = useState<Record<string, Category>>({});
   const [loading, setLoading] = useState(true);
 
   const load = useCallback(() => {
@@ -29,10 +32,14 @@ export default function ReportScreen() {
       getExpensesByMonth(monthKey),
       getIncomesByMonth(monthKey),
       getSettings(),
-    ]).then(([exps, incs, sets]) => {
+      getCategories(),
+    ]).then(([exps, incs, sets, cats]) => {
       setExpenses(exps);
       setIncomes(incs);
       setSettings(sets);
+      const map: Record<string, Category> = {};
+      cats.forEach((c) => (map[c.name] = c));
+      setCategoryMap(map);
       setLoading(false);
     });
   }, [monthKey]);
@@ -50,17 +57,19 @@ export default function ReportScreen() {
   const totalSpent = expenses.reduce((s, e) => s + e.price, 0);
   const totalIncome = incomes.reduce((s, i) => s + i.amount, 0);
   const available = totalIncome - totalSpent;
+  const currency = settings?.currency ?? 'EGP';
 
+  // Category breakdown sorted by total descending
   const byCategory: Record<string, number> = {};
   for (const e of expenses) byCategory[e.category] = (byCategory[e.category] ?? 0) + e.price;
-
-  const categories = Object.entries(byCategory)
+  const categoryBreakdown = Object.entries(byCategory)
     .sort((a, b) => b[1] - a[1])
     .map(([cat, amount]) => ({
       category: cat,
       total: amount,
       percentage: totalSpent > 0 ? amount / totalSpent : 0,
-      customEmojiMap: settings?.customCategoryEmojis ?? {},
+      categoryEmoji: categoryMap[cat]?.emoji ?? '📦',
+      categoryColor: categoryMap[cat]?.color ?? '#408A71',
     }));
 
   const handleDeleteExpense = (id: number) => {
@@ -81,18 +90,18 @@ export default function ReportScreen() {
 
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
 
-        {/* Top summary row */}
+        {/* Summary row */}
         <View style={styles.summaryRow}>
           <View style={[styles.summaryBox, { backgroundColor: colors.successBg }]}>
             <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Income</Text>
             <Text style={[styles.summaryValue, { color: colors.success }]}>
-              {formatCurrency(totalIncome, settings?.currency)}
+              {formatCurrency(totalIncome, currency)}
             </Text>
           </View>
           <View style={[styles.summaryBox, { backgroundColor: colors.dangerBg }]}>
             <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Spent</Text>
             <Text style={[styles.summaryValue, { color: colors.danger }]}>
-              {formatCurrency(totalSpent, settings?.currency)}
+              {formatCurrency(totalSpent, currency)}
             </Text>
           </View>
         </View>
@@ -103,16 +112,16 @@ export default function ReportScreen() {
         ]}>
           <Text style={[styles.balanceLabel, { color: colors.textSecondary }]}>Net Available</Text>
           <Text style={[styles.balanceValue, { color: available >= 0 ? colors.success : colors.danger }]}>
-            {available >= 0 ? '' : '-'}{formatCurrency(Math.abs(available), settings?.currency)}
+            {available >= 0 ? '' : '-'}{formatCurrency(Math.abs(available), currency)}
           </Text>
         </View>
 
-        {/* Expense breakdown */}
-        {categories.length > 0 && (
+        {/* Category breakdown */}
+        {categoryBreakdown.length > 0 && (
           <>
-            <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>Expenses by Category</Text>
-            {categories.map(c => (
-              <CategoryBar key={c.category} {...c} currency={settings?.currency ?? 'EGP'} />
+            <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>By Category</Text>
+            {categoryBreakdown.map((c) => (
+              <CategoryBar key={c.category} {...c} currency={currency} />
             ))}
           </>
         )}
@@ -124,12 +133,13 @@ export default function ReportScreen() {
         {expenses.length === 0 ? (
           <EmptyRow text="No expenses" />
         ) : (
-          expenses.map(exp => (
+          expenses.map((exp) => (
             <ExpenseTile
               key={exp.id}
               expense={exp}
-              currency={settings?.currency ?? 'EGP'}
-              customEmojiMap={settings?.customCategoryEmojis ?? {}}
+              currency={currency}
+              categoryEmoji={categoryMap[exp.category]?.emoji ?? '📦'}
+              categoryColor={categoryMap[exp.category]?.color ?? '#408A71'}
               onEdit={() => router.push({ pathname: '/add-expense', params: { expenseId: String(exp.id) } })}
               onDelete={() => handleDeleteExpense(exp.id)}
             />
@@ -143,11 +153,11 @@ export default function ReportScreen() {
         {incomes.length === 0 ? (
           <EmptyRow text="No income recorded" />
         ) : (
-          incomes.map(inc => (
+          incomes.map((inc) => (
             <IncomeTile
               key={inc.id}
               income={inc}
-              currency={settings?.currency ?? 'EGP'}
+              currency={currency}
               onDelete={load}
             />
           ))

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,73 +1,39 @@
 import React, { useCallback, useState } from 'react';
 import {
-  View, Text, ScrollView, TouchableOpacity, StyleSheet,
-  Switch, Alert, Modal, TextInput,
+  View, Text, ScrollView, TouchableOpacity, StyleSheet, Switch,
 } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@/theme/ThemeContext';
 import { getSettings, saveSettings } from '@/services/database';
-import { DEFAULT_CATEGORIES, CURRENCY_OPTIONS } from '@/services/constants';
+import { CURRENCY_OPTIONS } from '@/services/constants';
 import { Settings } from '@/types';
 import AppButton from '@/components/AppButton';
-
-const EMOJI_OPTIONS = ['🍕','🚗','🏠','👗','🎮','📱','✈️','🎓','💊','🛒','☕','🎁','💡','🐾','⚽'];
 
 export default function SettingsScreen() {
   const { colors, isDark, toggleTheme } = useTheme();
   const router = useRouter();
 
-  const [settings, setSettings] = useState<Settings | null>(null);
   const [currency, setCurrency] = useState('EGP');
-  const [customCategories, setCustomCategories] = useState<string[]>([]);
-  const [customEmojiMap, setCustomEmojiMap] = useState<Record<string, string>>({});
-  const [newCategory, setNewCategory] = useState('');
-  const [newCatEmoji, setNewCatEmoji] = useState('📦');
-  const [emojiPickTarget, setEmojiPickTarget] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const load = useCallback(() => {
-    getSettings().then((s) => {
-      setSettings(s);
-      setCurrency(s.currency ?? 'EGP');
-      setCustomCategories(s.customCategories ?? []);
-      setCustomEmojiMap(s.customCategoryEmojis ?? {});
-    });
+    getSettings().then((s: Settings) => setCurrency(s.currency ?? 'EGP'));
   }, []);
 
   useFocusEffect(load);
 
   const saveAll = async () => {
     setSaving(true);
-    await saveSettings({
-      currency,
-      customCategories,
-      customCategoryEmojis: customEmojiMap,
-    });
+    await saveSettings({ currency });
     setSaving(false);
     router.back();
   };
 
-  const addCategory = () => {
-    const name = newCategory.trim();
-    if (!name) return;
-    if ([...DEFAULT_CATEGORIES, ...customCategories].includes(name)) {
-      Alert.alert('Duplicate', 'This category already exists.');
-      return;
-    }
-    setCustomCategories(prev => [...prev, name]);
-    setCustomEmojiMap(prev => ({ ...prev, [name]: newCatEmoji }));
-    setNewCategory('');
-    setNewCatEmoji('📦');
-  };
-
-  const removeCategory = (cat: string) => {
-    setCustomCategories(prev => prev.filter(c => c !== cat));
-    setCustomEmojiMap(prev => { const n = { ...prev }; delete n[cat]; return n; });
-  };
-
   return (
     <View style={[styles.screen, { backgroundColor: colors.background }]}>
+
+      {/* Header */}
       <View style={[styles.header, { borderBottomColor: colors.border }]}>
         <TouchableOpacity onPress={() => router.back()}>
           <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
@@ -79,15 +45,17 @@ export default function SettingsScreen() {
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
 
         {/* Currency */}
-        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>Currency</Text>
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>CURRENCY</Text>
         <View style={styles.currencyRow}>
-          {CURRENCY_OPTIONS.map(c => (
+          {CURRENCY_OPTIONS.map((c) => (
             <TouchableOpacity
               key={c}
               style={[
                 styles.currencyPill,
-                { backgroundColor: currency === c ? colors.primary : colors.inputFill,
-                  borderColor: currency === c ? colors.primary : colors.border },
+                {
+                  backgroundColor: currency === c ? colors.primary : colors.inputFill,
+                  borderColor: currency === c ? colors.primary : colors.border,
+                },
               ]}
               onPress={() => setCurrency(c)}
             >
@@ -98,9 +66,15 @@ export default function SettingsScreen() {
           ))}
         </View>
 
-        {/* Dark mode */}
-        <View style={[styles.row, { backgroundColor: colors.card }]}>
-          <Text style={[styles.rowLabel, { color: colors.textPrimary }]}>🌙 Dark Mode</Text>
+        {/* Appearance */}
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>APPEARANCE</Text>
+        <View style={[styles.navRow, { backgroundColor: colors.card }]}>
+          <View style={styles.navRowLeft}>
+            <View style={[styles.navIcon, { backgroundColor: '#285A48' }]}>
+              <Ionicons name="moon-outline" size={16} color="#B0E4CC" />
+            </View>
+            <Text style={[styles.navLabel, { color: colors.textPrimary }]}>Dark Mode</Text>
+          </View>
           <Switch
             value={isDark}
             onValueChange={toggleTheme}
@@ -109,79 +83,30 @@ export default function SettingsScreen() {
           />
         </View>
 
-        {/* Custom categories */}
-        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>Custom Categories</Text>
-
-        {customCategories.map(cat => (
-          <View key={cat} style={[styles.catRow, { backgroundColor: colors.card }]}>
-            <TouchableOpacity
-              style={styles.catEmoji}
-              onPress={() => setEmojiPickTarget(cat)}
-            >
-              <Text style={{ fontSize: 22 }}>{customEmojiMap[cat] ?? '📦'}</Text>
-            </TouchableOpacity>
-            <Text style={[styles.catName, { color: colors.textPrimary }]}>{cat}</Text>
-            <TouchableOpacity onPress={() => removeCategory(cat)}>
-              <Ionicons name="trash-outline" size={20} color={colors.danger} />
-            </TouchableOpacity>
+        {/* Categories */}
+        <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>CATEGORIES</Text>
+        <TouchableOpacity
+          style={[styles.navRow, { backgroundColor: colors.card }]}
+          onPress={() => router.push('/categories')}
+          activeOpacity={0.75}
+        >
+          <View style={styles.navRowLeft}>
+            <View style={[styles.navIcon, { backgroundColor: colors.primary + '33' }]}>
+              <Ionicons name="pricetags-outline" size={16} color={colors.primary} />
+            </View>
+            <View>
+              <Text style={[styles.navLabel, { color: colors.textPrimary }]}>Manage Categories</Text>
+              <Text style={[styles.navSub, { color: colors.textSecondary }]}>
+                Add, edit & organise expense categories
+              </Text>
+            </View>
           </View>
-        ))}
-
-        <View style={[styles.addRow, { backgroundColor: colors.card }]}>
-          <TouchableOpacity
-            style={styles.emojiBtn}
-            onPress={() => setEmojiPickTarget('__new__')}
-          >
-            <Text style={{ fontSize: 22 }}>{newCatEmoji}</Text>
-          </TouchableOpacity>
-          <TextInput
-            style={[styles.addInput, { color: colors.textPrimary, borderColor: colors.border }]}
-            placeholder="New category name"
-            placeholderTextColor={colors.textSecondary}
-            value={newCategory}
-            onChangeText={setNewCategory}
-          />
-          <TouchableOpacity
-            style={[styles.addBtn, { backgroundColor: colors.primary }]}
-            onPress={addCategory}
-          >
-            <Ionicons name="add" size={20} color={colors.background} />
-          </TouchableOpacity>
-        </View>
+          <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+        </TouchableOpacity>
 
         <AppButton label="Save Settings" onPress={saveAll} loading={saving} />
         <View style={{ height: 60 }} />
       </ScrollView>
-
-      {/* Emoji picker modal */}
-      <Modal visible={!!emojiPickTarget} transparent animationType="slide">
-        <View style={styles.overlay}>
-          <View style={[styles.emojiModal, { backgroundColor: colors.card }]}>
-            <Text style={[styles.emojiTitle, { color: colors.textPrimary }]}>Pick an emoji</Text>
-            <View style={styles.emojiGrid}>
-              {EMOJI_OPTIONS.map(em => (
-                <TouchableOpacity
-                  key={em}
-                  style={styles.emojiOpt}
-                  onPress={() => {
-                    if (emojiPickTarget === '__new__') {
-                      setNewCatEmoji(em);
-                    } else if (emojiPickTarget) {
-                      setCustomEmojiMap(prev => ({ ...prev, [emojiPickTarget]: em }));
-                    }
-                    setEmojiPickTarget(null);
-                  }}
-                >
-                  <Text style={{ fontSize: 28 }}>{em}</Text>
-                </TouchableOpacity>
-              ))}
-            </View>
-            <TouchableOpacity onPress={() => setEmojiPickTarget(null)}>
-              <Text style={[styles.cancel, { color: colors.textSecondary }]}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 }
@@ -194,37 +119,16 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 18, fontWeight: '700' },
   content: { padding: 20 },
-  sectionLabel: { fontSize: 13, fontWeight: '600', marginBottom: 10, marginTop: 6 },
-  currencyRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginBottom: 20 },
-  currencyPill: {
-    paddingHorizontal: 18, paddingVertical: 10,
-    borderRadius: 10, borderWidth: 1.5,
-  },
+  sectionLabel: { fontSize: 11, fontWeight: '700', letterSpacing: 1, marginBottom: 10, marginTop: 6 },
+  currencyRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginBottom: 24 },
+  currencyPill: { paddingHorizontal: 18, paddingVertical: 10, borderRadius: 10, borderWidth: 1.5 },
   currencyText: { fontSize: 14, fontWeight: '600' },
-  row: {
+  navRow: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    padding: 16, borderRadius: 14, marginBottom: 20,
+    padding: 14, borderRadius: 14, marginBottom: 10,
   },
-  rowLabel: { fontSize: 15, fontWeight: '600' },
-  catRow: {
-    flexDirection: 'row', alignItems: 'center',
-    padding: 14, borderRadius: 12, marginBottom: 8,
-  },
-  catEmoji: { marginRight: 10 },
-  catName: { flex: 1, fontSize: 15, fontWeight: '600' },
-  addRow: {
-    flexDirection: 'row', alignItems: 'center',
-    padding: 12, borderRadius: 12, marginBottom: 20,
-  },
-  emojiBtn: { padding: 4, marginRight: 8 },
-  addInput: {
-    flex: 1, fontSize: 14, borderBottomWidth: 1, paddingVertical: 4, marginRight: 10,
-  },
-  addBtn: { width: 34, height: 34, borderRadius: 17, alignItems: 'center', justifyContent: 'center' },
-  overlay: { flex: 1, backgroundColor: '#00000066', justifyContent: 'flex-end' },
-  emojiModal: { borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 24 },
-  emojiTitle: { fontSize: 16, fontWeight: '700', marginBottom: 16, textAlign: 'center' },
-  emojiGrid: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', gap: 12 },
-  emojiOpt: { padding: 8 },
-  cancel: { textAlign: 'center', marginTop: 16, fontSize: 15 },
+  navRowLeft: { flexDirection: 'row', alignItems: 'center', flex: 1 },
+  navIcon: { width: 34, height: 34, borderRadius: 10, alignItems: 'center', justifyContent: 'center', marginRight: 12 },
+  navLabel: { fontSize: 15, fontWeight: '600' },
+  navSub: { fontSize: 12, marginTop: 2 },
 });

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -11,6 +11,43 @@ export const CATEGORY_EMOJIS: Record<string, string> = {
   Other: '📦',
 };
 
+/** 10-color accent palette for categories */
+export const CATEGORY_COLORS = [
+  '#408A71', // green  (primary)
+  '#4A90E2', // blue
+  '#E2844A', // orange
+  '#E24A4A', // red
+  '#9B59B6', // purple
+  '#F39C12', // amber
+  '#1ABC9C', // teal
+  '#E91E63', // pink
+  '#7F8C8D', // slate
+  '#2ECC71', // lime
+];
+
+/** Default seed colors per built-in category */
+export const DEFAULT_CATEGORY_COLORS: Record<string, string> = {
+  Food:      '#E2844A',
+  Bills:     '#4A90E2',
+  Transport: '#9B59B6',
+  Shopping:  '#E91E63',
+  Home:      '#408A71',
+  Other:     '#7F8C8D',
+};
+
+/** Emoji groups for the picker */
+export const EMOJI_GROUPS: { label: string; icon: string; emojis: string[] }[] = [
+  { label: 'Food',          icon: '🍔', emojis: ['🍔','🍕','🍣','🥗','🍜','🍰','☕','🍺','🥤','🍷','🧁','🥪','🌮','🥩','🍱'] },
+  { label: 'Transport',     icon: '🚗', emojis: ['🚗','🚕','🚌','✈️','🚂','🛵','🚢','🚲','⛽','🛺','🚁','🛸','🚐','🏎️','⛵'] },
+  { label: 'Home',          icon: '🏠', emojis: ['🏠','💡','🔧','🛁','🛋️','🏡','🔑','🪴','🧹','🛒','🪟','🛏️','🚿','🧺','🔒'] },
+  { label: 'Shopping',      icon: '🛍️', emojis: ['🛍️','👗','👟','👜','💄','🕶️','💍','🧴','👒','🎽','👔','🧥','💎','👓','🎒'] },
+  { label: 'Entertainment', icon: '🎮', emojis: ['🎮','🎬','🎵','📚','⚽','🎾','🏋️','🎭','🎲','🏊','🎸','🎯','🏀','🎤','🎨'] },
+  { label: 'Health',        icon: '💊', emojis: ['💊','🏥','🧘','🩺','💉','🩹','🧬','🌡️','🏃','🥦','🧪','🧠','❤️','🦷','🩻'] },
+  { label: 'Work',          icon: '💼', emojis: ['💼','💻','📱','🖥️','🎓','📝','📊','🗂️','🖨️','⌨️','📌','📎','🖊️','🗃️','🔬'] },
+  { label: 'Finance',       icon: '💰', emojis: ['💰','💳','🏦','📈','💵','🪙','💎','📉','🤑','🏧','🧾','💸','📊','🏷️','💱'] },
+  { label: 'Other',         icon: '📦', emojis: ['📦','🎁','🐾','👶','🌟','💯','🎪','🔮','🌈','✨','🎀','🌺','🍀','⚡','🔥'] },
+];
+
 export function monthKeyToLabel(monthKey: string): string {
   const [year, month] = monthKey.split('-');
   const date = new Date(parseInt(year), parseInt(month) - 1, 1);

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,5 +1,6 @@
 import * as SQLite from 'expo-sqlite';
-import { Expense, Income, Settings, MonthSummary } from '@/types';
+import { Category, Expense, Income, Settings, MonthSummary } from '@/types';
+import { DEFAULT_CATEGORIES, DEFAULT_CATEGORY_COLORS } from '@/services/constants';
 
 let _db: SQLite.SQLiteDatabase | null = null;
 
@@ -10,6 +11,8 @@ async function getDb(): Promise<SQLite.SQLiteDatabase> {
   }
   return _db;
 }
+
+// ── Schema ────────────────────────────────────────────────────
 
 async function initDb(db: SQLite.SQLiteDatabase): Promise<void> {
   await db.execAsync(`
@@ -36,7 +39,67 @@ async function initDb(db: SQLite.SQLiteDatabase): Promise<void> {
       key   TEXT PRIMARY KEY,
       value TEXT NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS categories (
+      id        INTEGER PRIMARY KEY AUTOINCREMENT,
+      name      TEXT    NOT NULL UNIQUE,
+      emoji     TEXT    NOT NULL DEFAULT '📦',
+      color     TEXT    NOT NULL DEFAULT '#408A71',
+      isDefault INTEGER NOT NULL DEFAULT 0,
+      sortOrder INTEGER NOT NULL DEFAULT 0,
+      createdAt TEXT    NOT NULL
+    );
   `);
+
+  await seedCategories(db);
+}
+
+// ── Category seed & migration ─────────────────────────────────
+
+const BUILT_IN: { name: string; emoji: string; sortOrder: number }[] = [
+  { name: 'Food',      emoji: '🍔', sortOrder: 0 },
+  { name: 'Bills',     emoji: '💡', sortOrder: 1 },
+  { name: 'Transport', emoji: '🚗', sortOrder: 2 },
+  { name: 'Shopping',  emoji: '🛍️', sortOrder: 3 },
+  { name: 'Home',      emoji: '🏠', sortOrder: 4 },
+  { name: 'Other',     emoji: '📦', sortOrder: 5 },
+];
+
+async function seedCategories(db: SQLite.SQLiteDatabase): Promise<void> {
+  const count = await db.getFirstAsync<{ n: number }>('SELECT COUNT(*) AS n FROM categories');
+  if (count && count.n > 0) return; // already seeded
+
+  const now = new Date().toISOString();
+
+  // Insert built-in categories
+  for (const cat of BUILT_IN) {
+    await db.runAsync(
+      'INSERT OR IGNORE INTO categories (name, emoji, color, isDefault, sortOrder, createdAt) VALUES (?,?,?,1,?,?)',
+      [cat.name, cat.emoji, DEFAULT_CATEGORY_COLORS[cat.name] ?? '#408A71', cat.sortOrder, now],
+    );
+  }
+
+  // Migrate old customCategories from settings JSON (if any)
+  const customCatsRow = await db.getFirstAsync<{ value: string }>(
+    "SELECT value FROM settings WHERE key='customCategories'",
+  );
+  const customEmojiRow = await db.getFirstAsync<{ value: string }>(
+    "SELECT value FROM settings WHERE key='customCategoryEmojis'",
+  );
+
+  if (customCatsRow?.value) {
+    const cats: string[] = JSON.parse(customCatsRow.value);
+    const emojis: Record<string, string> = customEmojiRow?.value
+      ? JSON.parse(customEmojiRow.value)
+      : {};
+    let sortOrder = BUILT_IN.length;
+    for (const cat of cats) {
+      await db.runAsync(
+        'INSERT OR IGNORE INTO categories (name, emoji, color, isDefault, sortOrder, createdAt) VALUES (?,?,?,0,?,?)',
+        [cat, emojis[cat] ?? '📦', '#408A71', sortOrder++, now],
+      );
+    }
+  }
 }
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -48,6 +111,117 @@ function nowIso(): string {
 function toMonthKey(iso: string): string {
   const d = new Date(iso);
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+// ── Categories CRUD ───────────────────────────────────────────
+
+export async function getCategories(): Promise<Category[]> {
+  const db = await getDb();
+  return db.getAllAsync<Category>(
+    'SELECT * FROM categories ORDER BY sortOrder ASC, id ASC',
+  );
+}
+
+export async function addCategory(
+  name: string,
+  emoji: string,
+  color: string,
+): Promise<number> {
+  const db = await getDb();
+  const trimmed = name.trim();
+
+  const existing = await db.getFirstAsync<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM categories WHERE LOWER(name)=LOWER(?)',
+    [trimmed],
+  );
+  if (existing && existing.n > 0) throw new Error('A category with this name already exists.');
+
+  const maxSort = await db.getFirstAsync<{ m: number }>(
+    'SELECT MAX(sortOrder) AS m FROM categories',
+  );
+  const sortOrder = (maxSort?.m ?? -1) + 1;
+
+  const result = await db.runAsync(
+    'INSERT INTO categories (name, emoji, color, isDefault, sortOrder, createdAt) VALUES (?,?,?,0,?,?)',
+    [trimmed, emoji, color, sortOrder, nowIso()],
+  );
+  return result.lastInsertRowId;
+}
+
+export async function updateCategory(
+  id: number,
+  name: string,
+  emoji: string,
+  color: string,
+): Promise<void> {
+  const db = await getDb();
+  const trimmed = name.trim();
+
+  const cat = await db.getFirstAsync<Category>(
+    'SELECT * FROM categories WHERE id=?',
+    [id],
+  );
+  if (!cat) throw new Error('Category not found.');
+
+  // Only check name uniqueness for custom (non-default) categories
+  if (!cat.isDefault) {
+    const dup = await db.getFirstAsync<{ n: number }>(
+      'SELECT COUNT(*) AS n FROM categories WHERE LOWER(name)=LOWER(?) AND id!=?',
+      [trimmed, id],
+    );
+    if (dup && dup.n > 0) throw new Error('A category with this name already exists.');
+  }
+
+  await db.runAsync(
+    'UPDATE categories SET emoji=?, color=?, name=? WHERE id=?',
+    [emoji, color, cat.isDefault ? cat.name : trimmed, id],
+  );
+
+  // Rename all expenses that use the old name (only relevant for custom categories)
+  if (!cat.isDefault && cat.name !== trimmed) {
+    await db.runAsync(
+      'UPDATE expenses SET category=? WHERE category=?',
+      [trimmed, cat.name],
+    );
+  }
+}
+
+export async function deleteCategory(
+  id: number,
+): Promise<{ ok: boolean; reason?: string }> {
+  const db = await getDb();
+
+  const cat = await db.getFirstAsync<Category>(
+    'SELECT * FROM categories WHERE id=?',
+    [id],
+  );
+  if (!cat) return { ok: false, reason: 'Category not found.' };
+  if (cat.isDefault) return { ok: false, reason: 'Built-in categories cannot be deleted.' };
+
+  const used = await db.getFirstAsync<{ n: number }>(
+    'SELECT COUNT(*) AS n FROM expenses WHERE category=?',
+    [cat.name],
+  );
+  if (used && used.n > 0) {
+    return {
+      ok: false,
+      reason: `"${cat.name}" is used by ${used.n} expense${used.n > 1 ? 's' : ''}. Delete those expenses first.`,
+    };
+  }
+
+  await db.runAsync('DELETE FROM categories WHERE id=?', [id]);
+  return { ok: true };
+}
+
+/** Returns a map of { [categoryName]: expenseCount } for all categories */
+export async function getCategoryUsageCounts(): Promise<Record<string, number>> {
+  const db = await getDb();
+  const rows = await db.getAllAsync<{ category: string; cnt: number }>(
+    'SELECT category, COUNT(*) AS cnt FROM expenses GROUP BY category',
+  );
+  const map: Record<string, number> = {};
+  rows.forEach((r) => (map[r.category] = r.cnt));
+  return map;
 }
 
 // ── Expenses ──────────────────────────────────────────────────
@@ -123,7 +297,6 @@ export async function getIncomesByMonth(monthKey: string): Promise<Income[]> {
 export async function getMonthHistory(): Promise<MonthSummary[]> {
   const db = await getDb();
 
-  // Get all months that appear in either table
   const months = await db.getAllAsync<{ monthKey: string }>(
     `SELECT DISTINCT monthKey FROM expenses
      UNION
@@ -131,7 +304,7 @@ export async function getMonthHistory(): Promise<MonthSummary[]> {
      ORDER BY monthKey DESC`,
   );
 
-  const summaries: MonthSummary[] = await Promise.all(
+  return Promise.all(
     months.map(async ({ monthKey }) => {
       const expRow = await db.getFirstAsync<{ total: number; cnt: number }>(
         'SELECT COALESCE(SUM(price),0) AS total, COUNT(*) AS cnt FROM expenses WHERE monthKey=?',
@@ -149,8 +322,6 @@ export async function getMonthHistory(): Promise<MonthSummary[]> {
       };
     }),
   );
-
-  return summaries;
 }
 
 // ── Settings ──────────────────────────────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,13 @@
+export interface Category {
+  id: number;
+  name: string;
+  emoji: string;
+  color: string;
+  isDefault: number; // 1 = built-in (no rename/delete), 0 = custom
+  sortOrder: number;
+  createdAt: string;
+}
+
 export interface Expense {
   id: number;
   price: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
       "@/theme/*": [
         "src/theme/*"
       ],
+      "@/types": [
+        "src/types/index.ts"
+      ],
       "@/types/*": [
         "src/types/*"
       ]


### PR DESCRIPTION
Closes #10

## What this PR does

### Architecture
- New `categories` SQLite table replaces JSON-in-settings approach
- Seeded with 6 built-in categories (Food, Bills, Transport, Shopping, Home, Other) each with a unique accent color
- Migration path: existing `customCategories` from old settings are automatically moved to the new table on first launch

### Category Manager Screen (`/categories`)
- Sectioned list: Built-in (lock badge, edit emoji/color only) + Custom (full CRUD)
- FAB + header button to add new category
- Bottom-sheet modal for Add/Edit with:
  - Live preview badge (emoji + color)
  - 10-color accent palette picker
  - Emoji picker: 9 groups × 15 emojis with scrollable tab bar (Food, Transport, Home, Shopping, Entertainment, Health, Work, Finance, Other)
  - Inline name input with validation + duplicate check
- Delete: blocked with reason if category is used by expenses (shows count)
- Empty state with CTA for no custom categories

### Propagation
- `AddExpenseScreen`: loads from DB, category pills use accent color as background
- `ExpenseTile` + `CategoryBar`: accept `categoryEmoji` + `categoryColor` props
- `HomeScreen` + `ReportScreen`: build `categoryMap` from DB on focus
- `SettingsScreen`: clean nav row `Manage Categories →`

### Bug fix
- Fixed `tsconfig.json` missing bare `@/types` path alias (was only `@/types/*`)
- Zero TypeScript errors after fix